### PR TITLE
Schedule dists separately, to count timeout separately for each

### DIFF
--- a/github-action.py
+++ b/github-action.py
@@ -867,18 +867,19 @@ def main():
                     log.info("Cannot find any allowed distributions.")
                     return
         for component in components:
-            cli_list.append(
-                AutoAction(
-                    builder_dir=args.builder_dir,
-                    config=config,
-                    component=component,
-                    distributions=distributions,
-                    state_dir=args.state_dir,
-                    commit_sha=commit_sha,
-                    repository_publish=repository_publish,
-                    local_log_file=local_log_file,
+            for dist in distributions:
+                cli_list.append(
+                    AutoAction(
+                        builder_dir=args.builder_dir,
+                        config=config,
+                        component=component,
+                        distributions=[dist],
+                        state_dir=args.state_dir,
+                        commit_sha=commit_sha,
+                        repository_publish=repository_publish,
+                        local_log_file=local_log_file,
+                    )
                 )
-            )
     elif args.command in ("build-template", "upload-template"):
         supported_templates = [t.name for t in config.get_templates()]
         # check if requested template name exists

--- a/tests/builder.yml
+++ b/tests/builder.yml
@@ -101,3 +101,9 @@ components:
   - input-proxy-clone:
       url: https://github.com/QubesOS/qubes-app-linux-input-proxy
       branch: v1.0.28
+  - builder-rpm:
+      packages: False
+      fetch-versions-only: false
+  - builder-debian:
+      packages: False
+      fetch-versions-only: false

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -295,6 +295,18 @@ def _upload_component_check(tmpdir, with_input_proxy=False):
 def test_action_build_template(workdir):
     tmpdir, env = workdir
 
+    # this normally is done by getting "build-component" call for
+    # builder-debian component when it gets updated; simulate it here
+    cmd = [
+        f"{tmpdir}/qubes-builderv2/qb",
+        f"--builder-conf={tmpdir}/builder.yml",
+        "-c",
+        "builder-debian",
+        "package",
+        "fetch",
+    ]
+    subprocess.run(cmd, check=True, env=env)
+
     timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
     with open(tmpdir / "timestamp", "w") as f:
         f.write(timestamp)

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -248,6 +248,16 @@ def test_rpc_05_build_template_command(workdir):
     # Adapt RPC for tests
     fix_scripts_dir(tmpdir, logfile=str(tmpdir / "build-command.log"), env=env)
 
+    # fetch builder-debian, but do similarly as normally it would be done 
+    subprocess.run(
+        [
+            str(tmpdir / "qubes-builder-github/rpc-services/qubesbuilder.TriggerBuild"),
+            "builder-debian",
+        ],
+        check=True,
+        env=env,
+    )
+
     # create signed build template command
     timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%M")
     with open(tmpdir / "timestamp", "w") as f:


### PR DESCRIPTION
Make the timeout apply to each target distribution separately, not all
of them at once. Otherwise builders targeting several distributions
would need increasing timeout just because of the target numbers, which
doesn't really scale well.