### PR TITLE
Implement build-iso

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-WIP: Integration with next generation of Qubes Builder:
+Integration with next generation of Qubes Builder:
 ===
 
 Parts below are mostly outdated and needs to be rewritten according to
@@ -34,6 +34,7 @@ top level key with settings:
 Optional:
 
   * `logs-repo` - repository in which every log are uploaded.
+  * `isos-url` - public URL where ISOs are uploaded. It is used only for comments.
   * `build-report-repo` - repository in which every build status package and template
     should have issue created (regardless of commenting issues mentioned in git log).
   * `maintainers` - GPG keys allowed to trigger GitHub command provided by the plugin.
@@ -46,10 +47,12 @@ github:
   state-dir: /home/user/github-notify-state
   build-report-repo: "fepitre/test-updates-status"
   logs-repo: "fepitre/test-build-logs"
+  isos-url: "https://qubes.notset.fr/iso/"
   maintainers:
     9FA64B92F95E706BF28E2CA6484010B5CDC576E2:
+      isos: true
       distributions:
-        - host-fc32
+        - host-fc37
         - vm-bookworm
       templates:
         - fedora-35-xfce
@@ -161,8 +164,9 @@ Each file is actually message template, which can contain following placeholders
  * `@REPOSITORY@` - either `testing` or `stable`
  * `@RELEASE_NAME@` - name of target Qubes release (`r2`, `r3.0` etc)
  * `@GIT_LOG@` - `git log --pretty=oneline previous_commit..current_commit` with github-like commits references
- * `@GIT_LOG_URL@` - GitHub URL to commits between previous version and the current one. "compare" github feature.
+ * `@GIT_LOG_URL@` - GitHub URL to commits between previous version and the current one. "compare" GitHub feature.
  * `@COMMIT_SHA@` - Commit SHA used to build the package.
+ * `@ISO_VERSION@` - ISO version.
 
 Ideally the message should include instruction how to install the update.
 
@@ -188,10 +192,10 @@ Installation
    See also 'RPC services configuration' chapter.
 
 3. (optional) Install GitHub webhooks (see `webhooks` directory)
-   somewhere reachable from github.com - this probably means `sys-net` in
+   somewhere reachable from `github.com` - this probably means `sys-net` in
    default Qubes OS installation. You need to configure a web server there to
    launch them as CGI scripts. Then add the hook(s) to repository/organization
-   configuration on github.com. Then fill
+   configuration on `github.com`. Then fill
    `~/.config/qubes-builder-github/build-vms.list` with a list to which
    information should be delivered (one per line). And setup qrexec policy for
    services mentioned in point 2 to actually allow such calls.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ top level key with settings:
 Optional:
 
   * `logs-repo` - repository in which every log are uploaded.
-  * `isos-url` - public URL where ISOs are uploaded. It is used only for comments.
+  * `iso-base-url` - public base URL where ISOs are uploaded (`iso` or `iso-testing` repositories). It is used only for comments.
   * `build-report-repo` - repository in which every build status package and template
     should have issue created (regardless of commenting issues mentioned in git log).
   * `maintainers` - GPG keys allowed to trigger GitHub command provided by the plugin.
@@ -47,10 +47,10 @@ github:
   state-dir: /home/user/github-notify-state
   build-report-repo: "fepitre/test-updates-status"
   logs-repo: "fepitre/test-build-logs"
-  isos-url: "https://qubes.notset.fr/iso/"
+  iso-base-url: "https://qubes.notset.fr/"
   maintainers:
     9FA64B92F95E706BF28E2CA6484010B5CDC576E2:
-      isos: true
+      iso: true
       distributions:
         - host-fc37
         - vm-bookworm

--- a/github-action.py
+++ b/github-action.py
@@ -898,7 +898,7 @@ class AutoActionISO(BaseAutoAction):
             log.error(msg)
 
     def upload(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def build(self):
         with timeout(self.timeout):

--- a/rpc-services/qubesbuilder.ProcessGithubCommand
+++ b/rpc-services/qubesbuilder.ProcessGithubCommand
@@ -48,6 +48,9 @@ case "$action" in
     Upload-template)
         "$scripts_dir/github-command.py" --log-basename "${log_basename}" --signer-fpr "$command_signer" Upload-template "$tmpdir/command"
         ;;
+    Build-iso)
+        "$scripts_dir/github-command.py" --log-basename "${log_basename}" --signer-fpr "$command_signer" Build-iso "$tmpdir/command"
+        ;;
     *)
         echo "Unknown command $action" >&2
         exit 1

--- a/templates/message-build-report
+++ b/templates/message-build-report
@@ -1,4 +1,4 @@
-Update of @COMPONENT@ to @VERSION@ for Qubes @RELEASE_NAME@, see comments below for details and build status.
+Update of @COMPONENT@ to @VERSION@ for Qubes OS @RELEASE_NAME@, see comments below for details and build status.
 
 From commit: @GIT_URL@/commit/@COMMIT_SHA@
 

--- a/templates/message-build-report-iso
+++ b/templates/message-build-report-iso
@@ -1,0 +1,3 @@
+ISO @ISO_VERSION@ for Qubes OS @RELEASE_NAME@, see comments below for details and build status.
+
+For more information on how to test this update, please take a look at https://www.qubes-os.org/doc/testing/#updates.

--- a/templates/message-build-report-template
+++ b/templates/message-build-report-template
@@ -1,4 +1,4 @@
-Template @TEMPLATE_NAME@ @VERSION@ for Qubes @RELEASE_NAME@, see comments below for details and build status.
+Template @TEMPLATE_NAME@ @VERSION@ for Qubes OS @RELEASE_NAME@, see comments below for details and build status.
 
 If you're release manager, you can issue GPG-inline signed command (depending on template):
 

--- a/tests/builder.yml
+++ b/tests/builder.yml
@@ -5,15 +5,17 @@ github:
   logs-repo: "fepitre/test-build-logs"
   maintainers:
     9FA64B92F95E706BF28E2CA6484010B5CDC576E2:
+      isos: true
       components: _all_
       distributions:
-        - host-fc32
+        - host-fc37
         - vm-bullseye
         - vm-fc36
       templates:
         - fedora-35-xfce
         - debian-11
     632F8C69E01B25C9E0C3ADF2F360C0D259FB650C:
+      isos: true
       components: _all_
       distributions: _all_
       templates: _all_
@@ -31,11 +33,11 @@ build_timeout: 21600
 fetch-versions-only: true
 
 use-qubes-repo:
-  version: 4.1
+  version: 4.2
   testing: true
 
 distributions:
-  - host-fc32
+  - host-fc37
   - vm-bullseye
   - vm-fc36
 
@@ -107,3 +109,6 @@ components:
   - builder-debian:
       packages: False
       fetch-versions-only: false
+
+iso:
+  kickstart: conf/iso-online-testing.ks

--- a/tests/builder.yml
+++ b/tests/builder.yml
@@ -5,7 +5,7 @@ github:
   logs-repo: "fepitre/test-build-logs"
   maintainers:
     9FA64B92F95E706BF28E2CA6484010B5CDC576E2:
-      isos: true
+      iso: true
       components: _all_
       distributions:
         - host-fc37
@@ -15,7 +15,7 @@ github:
         - fedora-35-xfce
         - debian-11
     632F8C69E01B25C9E0C3ADF2F360C0D259FB650C:
-      isos: true
+      iso: true
       components: _all_
       distributions: _all_
       templates: _all_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ artifacts-dir: {tmpdir}/artifacts
 repository-upload-remote-host:
   rpm: {tmpdir}/repo/rpm/r4.2
   deb: {tmpdir}/repo/deb/r4.2
+  iso: {tmpdir}/repo/iso/r4.2
 
 executor:
   type: qubes
@@ -47,6 +48,7 @@ executor:
             "clone",
             "-b",
             "main",
+            "--recurse-submodules",
             "https://github.com/QubesOS/qubes-builderv2",
         ]
     )

--- a/utils/notify-issues
+++ b/utils/notify-issues
@@ -653,9 +653,9 @@ def main():
         elif args.repo_type == "templates-itl-testing":
             add_labels += [f"{args.release_name}-testing"]
         elif args.repo_type == "templates-community":
-            delete_labels += [f"{args.release_name}-testing"]
+            delete_labels += [f"{args.release_name}-testing", "iso"]
             add_labels = [f"{args.release_name}-stable"]
-        elif args.repo_type in ("templates-community-testing", "isos-testing"):
+        elif args.repo_type in ("templates-community-testing", "iso-testing"):
             add_labels = [f"{args.release_name}-testing"]
         else:
             log.warning(f"Ignoring {args.repo_type}")

--- a/utils/notify-issues
+++ b/utils/notify-issues
@@ -64,7 +64,7 @@ class NotifyIssueCli:
         dist: QubesDistribution,
         message_templates_dir: Path,
         github_report_repo_name: str,
-        min_age_days: int
+        min_age_days: int,
     ):
         self.token = token
         self.release_name = release_name
@@ -227,6 +227,10 @@ class NotifyIssueCli:
             if component.startswith("qubes-template"):
                 message_template_path = (
                     self.message_templates_dir / "message-build-report-template"
+                )
+            elif component.startswith("iso"):
+                message_template_path = (
+                    self.message_templates_dir / "message-build-report-iso"
                 )
             else:
                 message_template_path = (
@@ -397,23 +401,36 @@ class NotifyIssueCli:
         build_status=None,
         build_log=None,
         additional_info=None,
+        repository_url=None,
     ):
+
+        if self.package_name.startswith("iso"):
+            base_message = f"ISO for {self.release_name}"
+            if repository_url:
+                upload_suffix_message = f"[testing]({repository_url}) repository"
+            else:
+                upload_suffix_message = f"testing repository"
+        else:
+            base_message = f"Package for {dist_label}"
+            upload_suffix_message = f"{repo_type} repository"
 
         if build_status == "building":
             report_message = None
         elif build_status == "failed":
             if build_log:
-                report_message = f"Package for {dist_label} failed to build ([build log]({build_log}))."
+                report_message = (
+                    f"{base_message} failed to build ([build log]({build_log}))."
+                )
             else:
-                report_message = f"Package for {dist_label} failed to build."
+                report_message = f"{base_message} failed to build."
             if additional_info:
                 report_message = f"{report_message.rstrip('.')} ({additional_info})."
         else:
             if build_log:
-                report_message = f"Package for {dist_label} was built ([build log]({build_log})) and uploaded to {repo_type} repository."
+                report_message = f"{base_message} was built ([build log]({build_log})) and uploaded to {upload_suffix_message}."
             else:
                 report_message = (
-                    f"Package for {dist_label} was uploaded to {repo_type} repository."
+                    f"{base_message} was uploaded to {upload_suffix_message}."
                 )
             if additional_info:
                 report_message = f"{report_message.rstrip('.')} ({additional_info})."
@@ -439,6 +456,11 @@ class NotifyIssueCli:
                 "@TEMPLATE_NAME@": template_name,
                 "@DIST@": os.getenv("DIST_ORIG_ALIAS", "(dist)"),
             }
+        elif self.package_name.startswith("iso"):
+            parsed_package_name = self.package_name.split("-")
+            version = parsed_package_name[-1]
+            component = "iso"
+            message_kwargs = {"@ISO_VERSION@": version}
         else:
             (
                 version,
@@ -525,6 +547,7 @@ def main():
             "templates-itl-testing",
             "templates-community",
             "templates-community-testing",
+            "isos-testing",
         ],
     )
     upload_parser.add_argument(
@@ -533,6 +556,11 @@ def main():
     upload_parser.add_argument(
         "stable_state_file",
         help="File to store internal state (previous commit id of a stable aka current package)",
+    )
+    upload_parser.add_argument(
+        "--repository-url",
+        help="URL where is uploaded the package, template or ISO.",
+        default=None,
     )
 
     # Build status
@@ -547,6 +575,10 @@ def main():
     args = parser.parse_args()
 
     token = args.auth_token or os.environ.get("GITHUB_API_KEY")
+    github_report_repo_name = args.github_report_repo_name or os.environ.get(
+        "GITHUB_BUILD_REPORT_REPO"
+    )
+
     if not token:
         log.error("Please provide GITHUB_API_KEY either as CLI arg or environ.")
         return 1
@@ -555,9 +587,6 @@ def main():
         log.error(f"Ignoring release {args.release_name}")
         return 1
 
-    github_report_repo_name = args.github_report_repo_name or os.environ.get(
-        "GITHUB_BUILD_REPORT_REPO"
-    )
     if not github_report_repo_name:
         log.error(
             "Please provide GITHUB_BUILD_REPORT_REPO either as CLI arg or environ."
@@ -583,7 +612,7 @@ def main():
         dist=dist,
         github_report_repo_name=github_report_repo_name,
         message_templates_dir=message_templates_dir,
-        min_age_days=args.days
+        min_age_days=args.days,
     )
 
     if dist.package_set == "host":
@@ -594,24 +623,30 @@ def main():
     add_labels = []
     delete_labels = []
     repo_type = None
+    if args.package_name.startswith("iso"):
+        prefix_label = f"{args.release_name}"
+    else:
+        prefix_label = f"{args.release_name}-{dist_label}"
+
     if args.command == "upload":
         build_status = None
         repo_type = args.repo_type
+        repository_url = args.repository_url
         delete_labels = [
-            f"{args.release_name}-{dist_label}-failed",
-            f"{args.release_name}-{dist_label}-building",
+            f"{prefix_label}-failed",
+            f"{prefix_label}-building",
         ]
         if args.repo_type == "current":
             repo_type = "stable"
             delete_labels += [
-                f"{args.release_name}-{dist_label}-cur-test",
-                f"{args.release_name}-{dist_label}-sec-test",
+                f"{prefix_label}-cur-test",
+                f"{prefix_label}-sec-test",
             ]
-            add_labels = [f"{args.release_name}-{dist_label}-stable"]
+            add_labels = [f"{prefix_label}-stable"]
         elif args.repo_type == "current-testing":
-            add_labels = [f"{args.release_name}-{dist_label}-cur-test"]
+            add_labels = [f"{prefix_label}-cur-test"]
         elif args.repo_type == "security-testing":
-            add_labels = [f"{args.release_name}-{dist_label}-sec-test"]
+            add_labels = [f"{prefix_label}-sec-test"]
         elif args.repo_type == "templates-itl":
             delete_labels += [f"{args.release_name}-testing"]
             add_labels = [f"{args.release_name}-stable"]
@@ -620,20 +655,21 @@ def main():
         elif args.repo_type == "templates-community":
             delete_labels += [f"{args.release_name}-testing"]
             add_labels = [f"{args.release_name}-stable"]
-        elif args.repo_type == "templates-community-testing":
+        elif args.repo_type in ("templates-community-testing", "isos-testing"):
             add_labels = [f"{args.release_name}-testing"]
         else:
             log.warning(f"Ignoring {args.repo_type}")
             return
     else:
+        repository_url = None
         build_status = args.status
         if build_status == "failed":
-            add_labels = [f"{args.release_name}-{dist_label}-{build_status}"]
-            delete_labels = [f"{args.release_name}-{dist_label}-building"]
+            add_labels = [f"-failed"]
+            delete_labels = [f"{prefix_label}-building"]
         elif build_status == "building":
-            add_labels = [f"{args.release_name}-{dist_label}-{build_status}"]
+            add_labels = [f"{prefix_label}-building"]
             # we ensure that we don't keep those labels in case of previous failures
-            delete_labels = [f"{args.release_name}-{dist_label}-failed"]
+            delete_labels = [f"{prefix_label}-failed"]
 
     current_commit = cli.get_current_commit()
     previous_stable_commit = None
@@ -676,6 +712,7 @@ def main():
             build_status=build_status,
             build_log=args.build_log,
             additional_info=args.additional_info,
+            repository_url=repository_url,
         )
     except NotifyIssueError as e:
         log.error(str(e))

--- a/utils/parse-command
+++ b/utils/parse-command
@@ -178,6 +178,37 @@ def validate_upload_template_command(untrusted_command: bytes) -> None:
             )
 
 
+def validate_build_iso_command(untrusted_command: bytes) -> None:
+    """
+    Validate a build iso command.
+    """
+    try:
+        (
+            command,
+            untrusted_release_name,
+            untrusted_iso_version,
+            untrusted_iso_timestamp,
+        ) = untrusted_command.split(b" ")
+    except ValueError:
+        raise BadCommandError(
+            "Build-iso takes 3 arguments: release name, iso version, and iso timestamp"
+        )
+    if command != b"Build-iso":
+        raise AssertionError("Wrong command passed to validate_build_iso_command")
+    if not untrusted_release_name:
+        raise BadCommandError("Empty release name")
+    if not untrusted_iso_version:
+        raise BadCommandError("Empty iso version")
+    timestamp_len = len(untrusted_iso_timestamp)
+    if timestamp_len != 12:
+        raise BadCommandError(f"Timestamp must be 12 bytes long, not {timestamp_len}")
+    for i in untrusted_iso_timestamp:
+        if not (0x30 <= i <= 0x39):
+            raise BadCommandError(
+                "Timestamp must be exactly 12 decimal digits, including leading zeros"
+            )
+
+
 def check_command(untrusted_command: bytes) -> None:
     """
     Check a command provided via a GitHub comment
@@ -208,6 +239,8 @@ def check_command(untrusted_command: bytes) -> None:
         validate_upload_template_command(untrusted_command)
     elif untrusted_command.startswith(b"Upload-component "):
         validate_upload_component_command(untrusted_command)
+    elif untrusted_command.startswith(b"Build-iso "):
+        validate_build_iso_command(untrusted_command)
     else:
         raise BadCommandError("Unknown command")
 


### PR DESCRIPTION
With several fixes, it allows to create a workflow for building testing ISO. It intends to be used for weekly builds in order to
reproduce stable/official releases build environment. Moreover, if openqa is configured, it would trigger tests suite.