### PR TITLE
When uploading to the stable repo, add generic label too

### DIFF
--- a/utils/notify_issues.py
+++ b/utils/notify_issues.py
@@ -96,7 +96,7 @@ class NotifyIssueCli:
                     f"{prefix_label}-cur-test",
                     f"{prefix_label}-sec-test",
                 ]
-                add_labels = [f"{prefix_label}-stable"]
+                add_labels = [f"{prefix_label}-stable", f"{self.release_name}-stable"]
             elif repository_type == "current-testing":
                 add_labels = [f"{prefix_label}-cur-test"]
             elif repository_type == "security-testing":


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#8724