### PR TITLE
Disarm sqv --not-after verification

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -66,7 +66,8 @@ read_stdin_command_and_verify_signature() {
         exit 1
     fi
 
-    if ! fpr=$(sqv --keyring "$local_keyring_path" -- \
+    future=$(date --iso-8601=seconds -d tomorrow)
+    if ! fpr=$(sqv --not-after "$future" --keyring "$local_keyring_path" -- \
             "$tmpdir/untrusted_command.sig" \
 	    "$tmpdir/untrusted_command"); then
         echo "Invalid signature" >&2


### PR DESCRIPTION
The signature is made just before posting it, a slight clock mismatch
(even 1s) makes sqv reject the signature. We don't really care when the
signature was made, we care about the content (which also includes the
timestamp), so provide some large enough margin (+24h). Unfortunately,
there seems to be no option to disable this check completely in sqv.