### PR TITLE
Allow custom messages dir to be specified

### DIFF
--- a/githubbuilder/action.py
+++ b/githubbuilder/action.py
@@ -314,7 +314,9 @@ class BaseAutoAction(ABC):
             "release_name": self.qubes_release,
             "source_dir": self.source_dir,
             "github_report_repo_name": self.build_report_repo,
-            "message_templates_dir": PROJECT_PATH / "templates",
+            "message_templates_dir": self.config.get("github", {}).get(
+                "message-templates-dir", PROJECT_PATH / "templates"
+            ),
             "min_age_days": self.config.get("min-age-days", 5),
         }
 

--- a/templates-status-only/message-build-report
+++ b/templates-status-only/message-build-report
@@ -1,0 +1,1 @@
+../templates/message-build-report

--- a/templates-status-only/message-build-report-iso
+++ b/templates-status-only/message-build-report-iso
@@ -1,0 +1,1 @@
+../templates/message-build-report-iso

--- a/templates-status-only/message-build-report-template
+++ b/templates-status-only/message-build-report-template
@@ -1,0 +1,1 @@
+../templates/message-build-report-template

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import subprocess
 
 from conftest import run_cmd
 from test_action import (


### PR DESCRIPTION
This in practice is needed to mute some notifications from the 'devel'
builder.